### PR TITLE
Fix compiler warning about unused variable

### DIFF
--- a/src/tiny_neopixel_heartbeat.cpp
+++ b/src/tiny_neopixel_heartbeat.cpp
@@ -9,9 +9,10 @@ extern "C" {
 #include "tiny_heartbeat.h"
 }
 
+#ifdef PIN_NEOPIXEL
+
 static tiny_timer_t timer;
 
-#ifdef PIN_NEOPIXEL
 #include <Adafruit_NeoPixel.h>
 
 static Adafruit_NeoPixel pixel(1, PIN_NEOPIXEL, NEO_GRB + NEO_KHZ800);


### PR DESCRIPTION
When `#PIN_NEOPIXEL` is undefined, I get the following compiler warning: 

`'timer' defined but not used [-Wunused-variable]`